### PR TITLE
chore: bump Synapse version to 1.104.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM matrixdotorg/synapse:v1.98.0
+FROM matrixdotorg/synapse:v1.104.0
 
 ARG S3_MEDIA_MODULE_VERSION=v1.4.0
 


### PR DESCRIPTION
self explaining